### PR TITLE
feat(lib): register and inject objection models

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ import { Module } from "@nestjs/common";
 import knex from "knex";
 import { knexSnakeCaseMappers } from "objection";
 import { ConfigModule, ConfigService } from "../config";
+import { User } from "./user";
 import { BaseModel } from "./base";
 
 @Module({
@@ -56,6 +57,9 @@ import { BaseModel } from "./base";
         },
       },
     }),
+
+    //Register your objection models so it can be provided when needed.
+    ObjectionModule.forFeature([User]),
   ],
   exports: [ObjectionModule],
 })
@@ -70,6 +74,7 @@ import { Module } from "@nestjs/common";
 import knex from "knex";
 import { knexSnakeCaseMappers } from "objection";
 import { ConfigModule, ConfigService } from "../config";
+import { User } from "./user";
 import { BaseModel } from "./base";
 
 @Module({
@@ -90,6 +95,8 @@ import { BaseModel } from "./base";
         };
       },
     }),
+    //Register your objection models so it can be provided when needed.
+    ObjectionModule.forFeature([User]),
   ],
   exports: [ObjectionModule],
 })
@@ -125,6 +132,22 @@ export class PrimaryDatabaseHealthIndicator extends HealthIndicator {
       const status = super.getStatus(key, false, { message: error.message });
       throw new HealthCheckError("Unable to connect to database", status);
     }
+  }
+}
+```
+
+### Injecting an objection model
+
+```ts
+import { Injectable, Inject } from "@nestjs/common";
+import { User } from "./user.model";
+
+@Injectable()
+export class UserService {
+  constructor(@Inject(User) private readonly userModel: typeof User) {}
+
+  async getUsers(): Promise<User[]> {
+    return await this.userModel.query();
   }
 }
 ```

--- a/lib/module.ts
+++ b/lib/module.ts
@@ -1,5 +1,6 @@
 /* eslint-disable new-cap */
-import { DynamicModule, Logger, Module } from "@nestjs/common";
+import { DynamicModule, Logger, Module, Provider } from "@nestjs/common";
+import { Model } from "objection";
 import { ObjectionCoreModule } from "./core";
 import {
   ObjectionModuleAsyncOptions,
@@ -40,6 +41,21 @@ export class ObjectionModule {
       module: ObjectionModule,
       imports: [ObjectionCoreModule.registerAsync(options)],
       exports: [ObjectionCoreModule],
+    };
+  }
+
+  public static forFeature(models: typeof Model[]): DynamicModule {
+    const modelProviders: Provider[] = models.map((model) => {
+      return {
+        useValue: model,
+        provide: model.name,
+      };
+    });
+
+    return {
+      module: ObjectionModule,
+      providers: modelProviders,
+      exports: modelProviders,
     };
   }
 }

--- a/tests/module.spec.ts
+++ b/tests/module.spec.ts
@@ -2,6 +2,7 @@ import { KNEX_CONNECTION, OBJECTION_BASE_MODEL } from "@/constants";
 import { ObjectionModule } from "@/module";
 import { Test, TestingModule } from "@nestjs/testing";
 import knex from "knex";
+import { Model } from "objection";
 
 describe("ObjectionModule", () => {
   let testingModule: TestingModule;
@@ -61,6 +62,24 @@ describe("ObjectionModule", () => {
     test("provides a base model", () => {
       const model = testingModule.get("ObjectionBaseModel");
 
+      expect(model).toBeDefined();
+    });
+  });
+
+  describe("#forFeature", () => {
+    beforeEach(async () => {
+      testingModule = await Test.createTestingModule({
+        imports: [
+          ObjectionModule.register({
+            config,
+          }),
+          ObjectionModule.forFeature([Model]),
+        ],
+      }).compile();
+    });
+
+    test("provides a model", () => {
+      const model = testingModule.get(Model);
       expect(model).toBeDefined();
     });
   });


### PR DESCRIPTION
@willsoto 

Based on the [brief discussions](https://github.com/willsoto/nestjs-objection/issues/564#issuecomment-632639446) we had earlier, I've added a static method in the `lib/module.ts` file to register objection models. This now makes it possible to inject objection models when needed.
